### PR TITLE
add 10.10 requirement, style fix and test block

### DIFF
--- a/mas.rb
+++ b/mas.rb
@@ -1,11 +1,17 @@
 class Mas < Formula
-  desc "Mac App Store command line interface"
+  desc "Mac App Store command-line interface"
   homepage "https://github.com/argon/mas"
   url "https://github.com/argon/mas/releases/download/v1.1.3/mas-cli.zip"
   version "1.1.3"
   sha256 "4509706dd3744c1ea7682d8642f78d5e7408258bd1f2490172f189fa5348f647"
 
+  depends_on :macos => :yosemite
+
   def install
     bin.install "mas"
+  end
+
+  test do
+    system "#{bin}/mas", "version"
   end
 end


### PR DESCRIPTION
I noticed that the private framework loaded is not on this 10.9.5 machine I'm sitting at, so I'm assuming Yosemite is a known requirement. I added that to the formula but also saw a couple violations in `brew audit --strict`, so I fixed those as well:
- suggested the spelling of "command-line"
- added a simple `test` block
